### PR TITLE
Jade compiling pretty markup by default.

### DIFF
--- a/src/plugins/jade-template.coffee
+++ b/src/plugins/jade-template.coffee
@@ -25,6 +25,7 @@ JadeTemplate.fromFile = (filename, base, callback) ->
       try
         rv = jade.compile buffer.toString(),
           filename: fullpath
+          pretty: true
         callback null, new JadeTemplate rv
       catch error
         callback error


### PR DESCRIPTION
Added `pretty: true` to `jade-template.coffee`

I feel the markup should be readable by default. I know Jade by default compresses it, but it's not pretty to look at. I plan to use Wintersmith as the basis for my own personal blog, and there's no way i'm having it powered by ugly looking markup.

:)
