### PR TITLE
Ability to run wintersmith preview over a specific domain

### DIFF
--- a/src/cli/preview.coffee
+++ b/src/cli/preview.coffee
@@ -11,6 +11,7 @@ usage = """
   options:
 
     -p, --port [port]             port to run server on (defaults to 8080)
+    -d, --domain [domain]         host to run server on (defaults to localhost)
     #{ commonUsage }
 
     all options can also be set in the config file
@@ -26,6 +27,9 @@ options =
   port:
     alias: 'p'
     default: 8080
+  domain:
+    alias: 'd'
+    default: 'localhost'
 
 extend options, commonOptions
 

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -81,7 +81,7 @@ run = (options) ->
   http = require 'http'
   server = http.createServer setup options
   server.listen options.port
-  serverUrl = "http://localhost:#{ options.port }/".bold
+  serverUrl = "http://#{ options.domain }:#{ options.port }/".bold
   logger.info "server running on: #{ serverUrl }"
 
 module.exports = setup


### PR DESCRIPTION
I was integrating livefyre into my wintersmith-based site, and run into issues with the domain my preview version was being served over. I wanted to preview it over the production domain on my local machine (using my hosts file to make my production domain temporarily resolve to my local machine), so that livefyre would function and I could test the integration.

I made a minor change so that you can use `-d` or `--domain` switches within the `wintersmith preview` command to define a specific domain / host over which the local server would run.

Initially I started out with `-h` and `--host`, but that conflicted with `-h` for `--help`...
