### PR TITLE
Allow local or arbitrary modules to be included in the template context

### DIFF
--- a/src/cli/common.coffee
+++ b/src/cli/common.coffee
@@ -105,8 +105,10 @@ exports.getOptions = (argv, callback) ->
       # load modules and add them to options.locals
       async.forEach options.require, (moduleName, callback) ->
         logger.verbose "loading module #{ moduleName }"
+        tmp = moduleName.split('/')
+        moduleAlias = tmp[tmp.length-1]
         try
-          options.locals[moduleName] = require moduleName
+          options.locals[moduleAlias] = require moduleName
           callback()
         catch error
           callback error


### PR DESCRIPTION
Currently, if an arbitrary module is included, for example `require: [ './myutils']`, it's impossible to access because the name of the module in wintersmith would be `/path/to/site/myutils`. This change uses the last part of the module path (`myutils` in this example) as the module name for the require statement.
