### PR TITLE
fixed blog example article.jade template

### DIFF
--- a/examples/blog/templates/article.jade
+++ b/examples/blog/templates/article.jade
@@ -2,7 +2,7 @@
 extends layout
 
 block prepend title
-  #{ page.title } -
+  | #{ page.title } - 
 
 block header
   include author


### PR DESCRIPTION
fixed blog example article.jade template

**page.title** was previously rendered as an html tag instead of plain text.
