### PR TITLE
Fix the articles sorting in feed.xml.

### DIFF
--- a/examples/blog/templates/feed.jade
+++ b/examples/blog/templates/feed.jade
@@ -4,8 +4,8 @@ rss(version='2.0',
     xmlns:wfw='http://wellformedweb.org/CommentAPI/',
     xmlns:dc='http://purl.org/dc/elements/1.1/'
     xmlns:atom='http://www.w3.org/2005/Atom')
-  channel
-    - var articles = contents.articles._.directories.map(function(item){ return item.index });
+  channel    
+    - var articles = _.chain(contents.articles._.directories).map(function(item){ return item.index }).sortBy(function(item) { return -item.date }).value();
     title= locals.name
     atom:link(href=locals.url + '/feed.xml', rel='self', type='application/rss+xml')
     link= locals.url


### PR DESCRIPTION
The articles in _feed.jade_ was ordered by the creation date. 

It may be an issue if I add a post to the past. The _feed.jade_ treats the old post as the latest post and causes the output _feed.xml_ with wrong `pubDate`.

I added the similar date sorting feature from _index.jade_ to _feed.jade_ to fix this issue.

Now it is ordered by the article's date meta.
