### PR TITLE
Use marked format-url branch, https

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/jnordberg/wintersmith.git"
   },
   "dependencies": {
-    "marked": "git://github.com/jnordberg/marked.git",
+    "marked": "git+https://github.com/jnordberg/marked.git#format-url",
     "coffee-script": "1.3.x",
     "async": "0.1.x",
     "highlight": "0.2.x",


### PR DESCRIPTION
If you agree with the pulls on your fork of marked, go with this.
