### PR TITLE
Expose marked in pages

### DIFF
--- a/src/plugins/page.coffee
+++ b/src/plugins/page.coffee
@@ -3,6 +3,7 @@ path = require 'path'
 async = require 'async'
 underscore = require 'underscore'
 moment = require 'moment'
+marked = require 'marked'
 
 {ContentPlugin} = require './../content'
 {stripExtension, extend} = require './../common'
@@ -49,6 +50,7 @@ class Page extends ContentPlugin
           contents: contents
           _: underscore
           moment: moment
+          marked: marked
         extend ctx, locals
         template.render ctx, callback
     ], callback


### PR DESCRIPTION
Any comments on this?

My use case is the following; I have some markdown files that are independent of pages but are included in a page (comments).

Exposing `marked` means I can render them inline within a template like so:

```
- var content = marked(contents.comments[url]._content)
| !{content}
```
