### PR TITLE
Provide baseurl option for the preview command

### DIFF
--- a/src/cli/preview.coffee
+++ b/src/cli/preview.coffee
@@ -12,6 +12,7 @@ usage = """
 
     -p, --port [port]             port to run server on (defaults to 8080)
     -d, --domain [domain]         host to run server on (defaults to localhost)
+    -b, --baseurl [url]           serve from a given base url (defaults to /)
     #{ commonUsage }
 
     all options can also be set in the config file
@@ -30,6 +31,9 @@ options =
   domain:
     alias: 'd'
     default: 'localhost'
+  baseurl:
+    alias: 'b'
+    default: '/'
 
 extend options, commonOptions
 

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -43,7 +43,8 @@ setup = (options, callback) ->
         # render if uri matches
         {contents, templates} = result
         async.detect ContentTree.flatten(contents), (item, callback) ->
-          callback (uri is item.url or (item.url[item.url.length - 1] is '/' and uri is (item.url + 'index.html')))
+          pathname = item.getUrl(options.baseurl)
+          callback (uri is pathname or (pathname[pathname.length - 1] is '/' and uri is (pathname + 'index.html')))
         , (result) ->
           if result
             result.render options.locals, contents, templates, (error, res) ->


### PR DESCRIPTION
The preview command now provides `baseurl` option, which allows serving the site from a given base url addressing the issue #84.
