### PR TITLE
Set Jade's compileDebug flag to false

### DIFF
--- a/src/plugins/jade-template.coffee
+++ b/src/plugins/jade-template.coffee
@@ -25,6 +25,7 @@ JadeTemplate.fromFile = (filename, base, callback) ->
         rv = jade.compile buffer.toString(),
           filename: fullpath
           pretty: true
+          compileDebug: false
         callback null, new this rv
       catch error
         callback error


### PR DESCRIPTION
Setting the `compileDebug` flag to `false` prevents compiling debug instrumentation which makes template inline code unnecessarily complicated in some cases.

For example the following will not work with `compileDebug` set to `true` (default)

```
- var array = ['first',
-   ...
-   'last'];
```

because each line will be interspersed with line number assignment used for debugging purposes.
