### PR TITLE
Changes date interpretation to assume UTC in blog example

### DIFF
--- a/examples/blog/templates/archive.jade
+++ b/examples/blog/templates/archive.jade
@@ -6,7 +6,7 @@ extends layout
 block content
   - var lineHeight = 2.2;
   - var archive = _.chain(env.helpers.getArticles(contents)).groupBy(function(item) {
-  -   return item.date.getFullYear()
+  -   return item.date.getUTCFullYear()
   - }).value()
   - var map = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
   section.archive
@@ -18,7 +18,7 @@ block content
         - var last = (years.length - 1 == i);
         li.year(style='height: '+h+'em')
           span.year-label(style='line-height: '+h+'em', class=(last?'last':''))= year
-          - var yearArticles = _.groupBy(archive[year], function(item) { return map[item.date.getMonth()] })
+          - var yearArticles = _.groupBy(archive[year], function(item) { return map[item.date.getUTCMonth()] })
           - var months = Object.keys(yearArticles);
           ul
             each month, i in months

--- a/examples/blog/templates/index.jade
+++ b/examples/blog/templates/index.jade
@@ -6,7 +6,7 @@ block content
     article.article.intro
       header
         p.date
-          span= moment(article.date).format('DD. MMMM YYYY')
+          span= moment.utc(article.date).format('DD. MMMM YYYY')
         h2
           a(href=article.url)= article.title
       section.content


### PR DESCRIPTION
To test this fix, switch your computer's timezone to PST (or something in the U.S.) and generate the blog before and after this fix.  Before the fix, the 'Red Herring' article will be displayed as '31. March 2013' , instead of '01. april 2013' in the articles, and categorized as March 2013 in the archive.

@jnordberg - I made this fix without fully rebuilding Wintersmith locally, but rather copied the fix from the generated blog template.  I'm having some trouble installing npm with the --dev flag (new to NPM development).   

...#113
