### PR TITLE
Fix destruction of page names that end in 'index.html'

### DIFF
--- a/src/plugins/page.coffee
+++ b/src/plugins/page.coffee
@@ -98,7 +98,7 @@ module.exports = (env, callback) ->
 
     getUrl: (base) ->
       # remove index.html for prettier links
-      super(base).replace /index\.html$/, ''
+      super(base).replace /([\/^])index\.html$/, '$1'
 
     getView: ->
       @metadata.view or 'template'


### PR DESCRIPTION
e.g. 'pageindex.html' became just 'page'
