### PR TITLE
Make `Page` more subclass-friendly

### DIFF
--- a/src/plugins/page.coffee
+++ b/src/plugins/page.coffee
@@ -129,7 +129,8 @@ module.exports = (env, callback) ->
       @metadata.filename or env.config.filenameTemplate or ':file.html'
 
     ### Template property used by the 'template' view ###
-    @property 'template', ->
+    @property 'template', 'getTemplate'
+    getTemplate: ->
       @metadata.template or env.config.defaultTemplate or 'none'
 
     @property 'title', ->


### PR DESCRIPTION
I really like the new filename template feature in Wintersmith 2, but it'd be nice if different kinds of content could have different default filename templates (without having to manually edit every page's metadata, of course).

For instance, on my site I want my blog posts to have a specific permalink structure that's different from the default in `config.json`. I could create a subclass of `Page` and override the `getFilename` method. But I don't want to _completely_ rewrite `getFilename`. I just want to override the first line:

``` coffee
# page.coffee
template = @metadata.filename or env.config.filenameTemplate or ':file.html'
```

To solve this, I've replaced the right part of this assignment with a call to a new property called `filenameTemplate`. Now ContentPlugins that inherit from `Page` can override `getFilenameTemplate` without having to completely reimplement the templating logic in `getFilename`.

For example, on my site now I can do this:

``` coffee
class BlogpostPage extends env.plugins.MarkdownPage
  getFilenameTemplate: ->
    env.config.blog.filenameTemplate or super()
```

(By the way, this is my first ever pull request, so I apologize if I've done something wrong!)
