### PR TITLE
Add default charset to Content-Type headers for text types.

### DIFF
--- a/src/core/server.coffee
+++ b/src/core/server.coffee
@@ -222,11 +222,17 @@ setup = (env) ->
           renderView env, content, locals, tree, templates, (error, result) ->
             if error then callback error
             else if result?
+              mimeType = mime.lookup(content.filename)
+              charset = mime.charsets.lookup(mimeType)
+              if charset
+                contentType = "#{mimeType}; charset=#{charset}"
+              else
+                contentType = mimeType
               if result instanceof Stream
-                response.writeHead 200, 'Content-Type': mime.lookup(content.filename)
+                response.writeHead 200, 'Content-Type': contentType
                 pump result, response, (error) -> callback error, 200
               else if result instanceof Buffer
-                response.writeHead 200, 'Content-Type': mime.lookup(content.filename)
+                response.writeHead 200, 'Content-Type': contentType
                 response.write result
                 response.end()
                 callback null, 200


### PR DESCRIPTION
No `charset` is specified in the `Content-Type` header. That leads some browsers to pick ISO-8859-1 or other legacy character encodings. That's probably not intended.

This patch causes a character encoding of `UTF-8` to be added to the `Content-Type` header if the file's mime type starts with `text/`.
