### PR TITLE
Change `getFilename` to use UTC time instead of local time

### DIFF
--- a/src/plugins/page.coffee
+++ b/src/plugins/page.coffee
@@ -73,9 +73,9 @@ module.exports = (env, callback) ->
       ext = path.extname basename
 
       filename = replaceAll template,
-        ':year': @date.getFullYear()
-        ':month': ('0' + (@date.getMonth()+1)).slice(-2)
-        ':day': ('0' + @date.getDate()).slice(-2)
+        ':year': @date.getUTCFullYear()
+        ':month': ('0' + (@date.getUTCMonth()+1)).slice(-2)
+        ':day': ('0' + @date.getUTCDate()).slice(-2)
         ':title': slugify(@title+'')
         ':file': file
         ':ext': ext


### PR DESCRIPTION
I noticed when using dates in the `filenameTemplate`, the day is off by one. I figured out that this is because JavaScript's Date object constructor defaults to 0:00 UTC if no timezone is specified, but the standard getter methods like `getDate` output local time. Because I'm in Eastern Standard Time, my dates were being calculated as 0:00 minus 6 hours, which is actually the day before the one I intended!

This patch changes the `getFilename` method to use UTC instead of local time when constructing the filename. I think a better solution would be to somehow make the timezone of the output configurable, but that'll be fairly tricky since you have to account for Daylight Saving and all that. Perhaps it would be best to use something like http://momentjs.com/timezone/?

Anyway, this should work for now, and it matches the solution used in the Jade templates: https://github.com/jnordberg/wintersmith/pull/135
