### PR TITLE
updated templates to use doctype html instead of deprecated `!!!`

### DIFF
--- a/examples/basic/templates/index.jade
+++ b/examples/basic/templates/index.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 html(lang='en')
   head
     meta(charset='utf-8')

--- a/examples/blog/templates/layout.jade
+++ b/examples/blog/templates/layout.jade
@@ -1,4 +1,4 @@
-!!! 5
+doctype html
 block vars
   - var bodyclass = null;
 html(lang='en')


### PR DESCRIPTION
Resolves the build / preview error:

template archive.jade: /Users/alex/code/blog/templates/layout.jade:1

> 1| !!! 5
>     2| block vars
>     3|   - var bodyclass = null;
>     4| html(lang='en')

`!!!` is deprecated, you must now use `doctype`
