### PR TITLE
Markdown links can be resolved to content tree nodes

### DIFF
--- a/examples/blog/contents/articles/hello-world/index.md
+++ b/examples/blog/contents/articles/hello-world/index.md
@@ -72,5 +72,37 @@ proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
 
 ```
 
-This is where I leave you to your own devices. Join **#wintersmith** on freenode if you have any questions.
 
+### Links
+
+Links can be added via the markdown syntax
+ * absolute links
+ * relative to current node in the content tree
+ * relative to root node in the content tree
+ * anchor on a node of the content tree
+ * all other links will be resolved based on the url of the current page
+
+Here are some markdown examples followed by the generated links
+
+```markdown
+ * [absolute url to wintersmith website](http://wintersmith.io/)
+```
+ * [absolute url to wintersmith website](http://wintersmith.io/)
+
+```markdown
+ * [relative to the current content tree node](../bamboo-cutter/index.md)
+```
+* [relative to the current content tree node](../bamboo-cutter/index.md)
+
+```markdown
+ * [relative to the content tree root node](/articles/red-herring/index.md)
+```
+ * [relative to the content tree root node](/articles/red-herring/index.md)
+
+```markdown
+ * [anchor on the content tree](../markdown-syntax/index.md#link)
+```
+ * [anchor on the content tree](../markdown-syntax/index.md#link)
+
+
+This is where I leave you to your own devices. Join **#wintersmith** on freenode if you have any questions.

--- a/src/plugins/markdown.coffee
+++ b/src/plugins/markdown.coffee
@@ -14,11 +14,38 @@ if not marked.InlineLexer.prototype._outputLink?
     link.href = @_resolveLink link.href
     return @_outputLink cap, link
 
-parseMarkdownSync = (content, baseUrl, options) ->
-  ### Parse markdown *content* and resolve links using *baseUrl*, returns html. ###
+parseMarkdownSync = (content, markdown, baseUrl, options) ->
+  ### Parse *markdown* found on *content* node of contents and
+  resolve links by navigating in the content tree. use *baseUrl* as a last resort
+  returns html. ###
 
   marked.InlineLexer.prototype._resolveLink = (uri) ->
-    url.resolve baseUrl, uri
+    link = null
+    uriParts = url.parse uri
+    if uriParts.protocol
+      # absolute uri
+      link = uri
+    else if uriParts.pathname
+      # search pathname in content tree relative to *content*
+      nav = content.parent
+      path = uriParts.pathname.split '/'
+      while path.length
+        part = path.shift()
+        if part == ''
+          # uri begins with / go to contents root
+          nav = nav.parent while nav.parent
+        else if part == '..'
+          nav = nav.parent
+        else
+          try
+            nav = nav[part]
+            link = nav.getUrl() + [uriParts.hash] if nav.getUrl
+          catch error
+            # error while navigating in content tree
+            break
+      
+    
+    link ?= url.resolve baseUrl, uri 
 
   options.highlight = (code, lang) ->
     if lang?
@@ -31,7 +58,7 @@ parseMarkdownSync = (content, baseUrl, options) ->
       return code
 
   marked.setOptions options
-  return marked content
+  return marked markdown
 
 module.exports = (env, callback) ->
 
@@ -46,7 +73,7 @@ module.exports = (env, callback) ->
     getHtml: (base=env.config.baseUrl) ->
       ### parse @markdown and return html. also resolves any relative urls to absolute ones ###
       options = env.config.markdown or {}
-      return parseMarkdownSync @markdown, @getLocation(base), options
+      return parseMarkdownSync this, @markdown, @getLocation(base), options
 
   MarkdownPage.fromFile = (filepath, callback) ->
     async.waterfall [


### PR DESCRIPTION
I ran into a limitation of the way the Markdown plugin resolves url :
- it works well when linking to a file in the same directory as the .md file (showing an image for example)
- it does not work when linking to another node of the content tree (a link to another article for example)

This PR changes the way the links are resolved by the Markdown plugin in order to accept the following :

```
 * [relative to the current content tree node](../bamboo-cutter/index.md)
 * [relative to the content tree root node](/articles/red-herring/index.md)
 * [anchor on the content tree](../markdown-syntax/index.md#link)
```

All other cases (absolute urls, basic anchors, error cases for example when the path is not in the content tree) give the same result as before.

I modified the blog "hello world" article to list those cases.

I hope you will be able to review it and hopefully accept it !
