### PR TITLE
bugfix: renderer creates more than _fileLimit files at a time

### DIFF
--- a/src/core/renderer.coffee
+++ b/src/core/renderer.coffee
@@ -53,9 +53,7 @@ render = (env, outputDir, contents, templates, locals, callback) ->
         if result instanceof Stream
           pump result, writeStream, callback
         else
-          writeStream.write result
-          writeStream.end()
-          callback()
+          writeStream.end result, callback
       else
         env.logger.verbose "skipping #{ content.url }"
         callback()


### PR DESCRIPTION
this PR fixes an async issue with the renderer.
the current code does not wait until a file is really created before sending the callback to the async _fileLimit.

this leads to an overflow on file descriptors when there is a lot of files (around 800 blog posts).

This PR hopefully fixes https://github.com/jnordberg/wintersmith/issues/205
