### PR TITLE
bumped jade dependency to 1.x.x and fixed syntax warning

### DIFF
--- a/examples/blog/templates/index.jade
+++ b/examples/blog/templates/index.jade
@@ -10,7 +10,7 @@ block content
         h2
           a(href=article.url)= article.title
       section.content
-        !{ typogr(article.intro).typogrify() }
+        | !{ typogr(article.intro).typogrify() }
         if article.hasMore
           p.more
             a(href=article.url) more

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffee-script": ">=1.3.0",
     "async": "0.2.x",
     "highlight.js": "7.x.x",
-    "jade": ">=0.25.0",
+    "jade": "1.x.x",
     "ncp": "0.2.x",
     "rimraf": "2.x.x",
     "winston": "0.6.x",


### PR DESCRIPTION
Fix for issue: https://github.com/jnordberg/wintersmith/issues/208 
