### PR TITLE
Add a last.page item to contents  & current pageNum variable to paginator.coffee

### DIFF
--- a/examples/blog/plugins/paginator.coffee
+++ b/examples/blog/plugins/paginator.coffee
@@ -43,7 +43,7 @@ module.exports = (env, callback) ->
         return callback new Error "unknown paginator template '#{ options.template }'"
 
       # setup the template context
-      ctx = {@articles, @prevPage, @nextPage}
+      ctx = {@articles, @pageNum, @prevPage, @nextPage}
 
       # extend the template context with the enviroment locals
       env.utils.extend ctx, locals
@@ -76,6 +76,7 @@ module.exports = (env, callback) ->
     for page in pages
       rv.pages["#{ page.pageNum }.page"] = page # file extension is arbitrary
     rv['index.page'] = pages[0] # alias for first page
+    rv['last.page'] = pages[(numPages-1)] # alias for last page
 
     # callback with the generated contents
     callback null, rv


### PR DESCRIPTION
For my own blog I wanted to highlight the current page number and and a short-cut to the last page.
I have added the required data in the contents and ctx variables for use in the templates.
