### PR TITLE
fix template lookup cross-platform by normalizing template path

### DIFF
--- a/src/plugins/page.coffee
+++ b/src/plugins/page.coffee
@@ -16,7 +16,7 @@ module.exports = (env, callback) ->
     if @template == 'none'
       return callback null, null
 
-    template = templates[@template]
+    template = templates[path.normalize @template]
     if not template?
       callback new Error "page '#{ @filename }' specifies unknown template '#{ @template }'"
       return


### PR DESCRIPTION
My team works on *-nix systems, but deliver code to our client who uses Windows systems. I discovered that, although the `templates` hash in `plugins/page.coffee` sets it's keys using normalized paths, when doing the lookup from the page's JSON file, it does not normalize the specified template path, causing an error to be thrown.

For instance, if my template path is specified as `subdirectory/template.jade` - this works fine on *-nix, but on Windows, the `templates` key is normalized to `subdirectory\\template.jade`, but we aren't normalizing `@template` before looking it up, so Wintersmith throws the error at line 21.

I was able to resolve this simply by normalizing the `@template` before looking it up in the hash.
