### PR TITLE
new plugin type: postContentPlugins

### DIFF
--- a/src/core/content.coffee
+++ b/src/core/content.coffee
@@ -207,8 +207,13 @@ ContentTree.fromDirectory = (env, directory, callback) ->
             loadContent env, filepath, (error, instance) ->
               if not error
                 instance.parent = tree
-                tree[basename] = instance
-                tree._[instance.__plugin.group].push instance
+                plugins = (p for p in env.postContentPlugins when minimatch thisInstance.filename, p.pattern, minimatchOptions)
+                handlePlugin = (thisInstance, plugin, next) -> plugin.class.handlePage(thisInstance, next)
+                async.reduce plugins, instance, handlePlugin, (err, instance) ->
+                  if err then return callback(err)
+                  tree[basename] = instance
+                  tree._[instance.__plugin.group].push instance
+              else
               callback error
 
           # This should never happen™

--- a/src/core/environment.coffee
+++ b/src/core/environment.coffee
@@ -40,6 +40,7 @@ class Environment extends EventEmitter
     @plugins = {StaticFile}
     @templatePlugins = []
     @contentPlugins = []
+    @postContentPlugins = []
     @helpers = {}
 
     while id = @loadedModules.pop()
@@ -112,6 +113,14 @@ class Environment extends EventEmitter
     @logger.verbose "registering content plugin #{ plugin.name } that handles: #{ pattern }"
     @plugins[plugin.name] = plugin
     @contentPlugins.push
+      group: group
+      pattern: pattern
+      class: plugin
+
+  registerPostContentPlugin: (group, pattern, plugin) ->
+    @logger.verbose "registering post-content plugin #{ plugin.name } that handles: #{ pattern }"
+    @plugins[plugin.name] = plugin
+    @postContentPlugins.push
       group: group
       pattern: pattern
       class: plugin


### PR DESCRIPTION
I don't intend for this to be merged as-is, but rather to start a discussion. I started running into some problems that would be solved by something such as #144, and did some hacky workarounds that I wasn't proud of.  Then I wanted to do something that required access to the contentTree, but wasn't really a generator.  So I thought on it a bit, and came up with the "postContentPlugin". 

After the ContentPlugin has run and after the tree has been attached to the content instance, a postContentPlugin that matches a pattern against the instance.filename will run to do further processing on the page instance.  Examples of use:
1. modifying the html to fix a bug in the content plugin: https://github.com/mattly/lyonheart.us/blob/master/plugins/fix_old_typogr_bug.coffee
2. pulling in extra metadata from somewhere else: https://github.com/mattly/lyonheart.us/blob/master/plugins/metadata.coffee
3. modifying both the page html and the metadata, taking markdown footnotes from the html and moving them to metadata: https://github.com/mattly/lyonheart.us/blob/master/plugins/footnote-extraction.coffee

This solution is extra-nice for the third one, previously I was "extending" wintersmith-showdown [by chaining its render](https://github.com/mattly/lyonheart.us/commit/8d3d60d8fe4dd5b6c9cc2053e035de6a4a395a62#diff-29347f2c6fe55f298393a02f0f052c1bL31) but that's really hacky and doesn't scale to many plugins well.  I think this solution is more elegant.

Anyway, let me know what you think. I like working with wintersmith so far and I have a lot of ideas for things that extending it this way will let me do.
