### PR TITLE
Support baseUrl in jade templates fix #176

### DIFF
--- a/examples/blog/config.json
+++ b/examples/blog/config.json
@@ -8,9 +8,11 @@
   "plugins": [
     "./plugins/paginator.coffee"
   ],
+    "baseUrl": "/blog/",
   "require": {
     "moment": "moment",
     "_": "underscore",
+    "urlPackage": "url",
     "typogr": "typogr"
   },
   "jade": {

--- a/examples/blog/templates/feed.jade
+++ b/examples/blog/templates/feed.jade
@@ -7,7 +7,7 @@ rss(version='2.0',
   channel
     - var articles = env.helpers.getArticles(contents);
     title= locals.name
-    atom:link(href=locals.url + '/feed.xml', rel='self', type='application/rss+xml')
+    atom:link(href=urlPackage.resolve(env.config.baseUrl, '/feed.xml'), rel='self', type='application/rss+xml')
     link= locals.url
     description= locals.description
     pubDate= articles[0].rfc822date

--- a/examples/blog/templates/index.jade
+++ b/examples/blog/templates/index.jade
@@ -20,7 +20,7 @@ block prepend footer
     if prevPage
       a(href=prevPage.url) « Newer
     else
-      a(href='/archive.html') « Archives
+      a(href=urlPackage.resolve(env.config.baseUrl, 'archive.html')) « Archives
     if nextPage
       a(href=nextPage.url) Next page »
 

--- a/examples/blog/templates/layout.jade
+++ b/examples/blog/templates/layout.jade
@@ -10,16 +10,16 @@ html(lang='en')
       title
         block title
           = locals.name
-      link(rel='alternate', href=locals.url+'/feed.xml', type='application/rss+xml', title=locals.description)
+      link(rel='alternate', href=urlPackage.resolve(env.config.baseUrl, '/feed.xml'), type='application/rss+xml', title=locals.description)
       link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Anonymous+Pro:400,700,400italic,700italic|Merriweather:400,700,300')
-      link(rel='stylesheet', href='/css/main.css')
+      link(rel='stylesheet', href=urlPackage.resolve(env.config.baseUrl, 'css/main.css'))
   body(class=bodyclass)
     header.header
       div.content-wrap
         block header
           div.logo
             h1
-              a(href=locals.url)= locals.name
+              a(href=env.config.baseUrl)= locals.name
             p.description= locals.description
     div#content
       div.content-wrap


### PR DESCRIPTION
- fix jnordberg/wintersmith#176
- The links in jade templates is hardwired to root, which break any
  usage of baseUrl
- Load package `url` for jade
- Add baseUrl to links in jade templates 
