### PR TITLE
fixed broken about

### DIFF
--- a/examples/blog/contents/about.md
+++ b/examples/blog/contents/about.md
@@ -1,5 +1,5 @@
 ---
-view: none
+template: article.jade
 ---
 
 Wintersmith is made by [Johan Nordberg][1] and licensed under the [MIT-license][2].


### PR DESCRIPTION
The about page doesn't compile and therefore doesn't render at `/about.html` where it's supposed to. Which is pretty confusing when trying to learn how pages work.
