### PR TITLE
Duplicate file changed events (Windows-only?)

### DIFF
--- a/src/core/server.coffee
+++ b/src/core/server.coffee
@@ -128,7 +128,7 @@ setup = (env) ->
       return false
     ignoreInitial: true
   contentWatcher.on 'change', (path) ->
-    return if not contents? or block.contentsLoad
+    return if not contents? or block.contentsLoad or block.contentChange
     # ignore if we dont have the tree loaded or it's loading
 
     block.contentChange = true


### PR DESCRIPTION
Hi,

When running the preview server on Windows, it frequently crashes with the message

```
Content #{ content.filename } not found in its plugin group!
```

The cause seems to be that two 'change' events are fired in quick succession and their processing is interleaved, so when the second one reaches the replaceInArray() call it cannot find the original content in the array.

Changeset cbd1c14 fixes this in a very coarse way, by only processing a single 'change' event at once. If this is no good, a finer-grained approach (blocking on each individual file) is also possible.

Note that this also means that the use of block.contentChange is broken in the presence of concurrent change events - it is reset to false when the first change finishes processing.

The other changeset (583f85f) fixes the use of apostrophes in the messages.
