### PR TITLE
use baseUrl in the autogenerated code and/or examples

### DIFF
--- a/examples/blog/templates/index.jade
+++ b/examples/blog/templates/index.jade
@@ -20,7 +20,7 @@ block prepend footer
     if prevPage
       a(href=prevPage.url) « Newer
     else
-      a(href='/archive.html') « Archives
+      a(href="#{locals.env.config.baseUrl}/archive.html") « Archives
     if nextPage
       a(href=nextPage.url) Next page »
 

--- a/examples/blog/templates/layout.jade
+++ b/examples/blog/templates/layout.jade
@@ -12,7 +12,7 @@ html(lang='en')
           = locals.name
       link(rel='alternate', href=locals.url+'/feed.xml', type='application/rss+xml', title=locals.description)
       link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Anonymous+Pro:400,700,400italic,700italic|Merriweather:400,700,300')
-      link(rel='stylesheet', href='/css/main.css')
+      link(rel='stylesheet', href="#{locals.env.config.baseUrl}/css/main.css")
   body(class=bodyclass)
     header.header
       div.content-wrap


### PR DESCRIPTION
it took me a while to figure out while CSS wasn't loading even after I applied the `baseUrl` to the config.json file, this fix should help other beginners :crossed_flags:
