### PR TITLE
add an option to use root level articles if articles is empty or false (...

### DIFF
--- a/examples/blog/plugins/paginator.coffee
+++ b/examples/blog/plugins/paginator.coffee
@@ -18,6 +18,15 @@ module.exports = (env, callback) ->
   getArticles = (contents) ->
     # helper that returns a list of articles found in *contents*
     # note that each article is assumed to have its own directory in the articles directory
+    # use root level articles if articles is empty or false (above or in config.json under paginator)
+    # root level articles defined by the `article.jade` template
+    # the structe is similar: folder -> index.md, folder name become the slug
+    unless options.articles
+      articles = []
+      for key, value of contents
+        if value['index.md']? and value['index.md'].metadata?.template is 'article.jade' then articles.push value['index.md']
+    else
+      articles = contents[options.articles]._.directories.map (item) -> item.index
     articles = contents[options.articles]._.directories.map (item) -> item.index
     articles.sort (a, b) -> b.date - a.date
     return articles


### PR DESCRIPTION
...above or in config.json under paginator);root level articles defined by the  template; the structe is similar: folder -> index.md, folder name become the slug, e.g.,

instead of `/articles/my-post` it's now possible to have `/my-post`
