### PR TITLE
Add URL search/replace patching

### DIFF
--- a/src/core/content.coffee
+++ b/src/core/content.coffee
@@ -48,6 +48,8 @@ class ContentPlugin
     base ?= @__env.config.baseUrl
     if not base.match /\/$/
       base += '/'
+    for s, r of @__env.config?.patchUrl
+      filename = filename.replace new RegExp(s), r
     if process.platform is 'win32'
       filename = filename.replace /\\/g, '/' #'
     return url.resolve base, filename


### PR DESCRIPTION
Add new config.json entry, "patchUrl", which is a dictionary of regex searches (keys) and corresponding replacements (values).

These rules are applied to URL links when they are automatically generated from the contents directory structure.

This allows, for example, using one wintersmith contents directory to contain content for multiple virtual sites.