### PR TITLE
Handle urls without trailing slashes when previewing.

### DIFF
--- a/src/core/server.coffee
+++ b/src/core/server.coffee
@@ -32,6 +32,7 @@ sleep = (callback) -> setTimeout callback, 50
 
 normalizeUrl = (anUrl) ->
   anUrl += 'index.html' if anUrl[anUrl.length - 1] is '/'
+  anUrl += '/index.html' if anUrl.match(/^([^.]*[^/])$/)
   anUrl = decodeURI anUrl
   return anUrl
 


### PR DESCRIPTION
Solved this issue https://github.com/jnordberg/wintersmith/issues/214.  

If a URL does not contain a dot and does not end in a slash, then we add "/index.html".  
