### PR TITLE
Use private instead of dummy repository

### DIFF
--- a/examples/webapp/package.json
+++ b/examples/webapp/package.json
@@ -5,5 +5,5 @@
     "wintersmith-nunjucks": "*",
     "browsernizr": "*"
   },
-  "repository": "none"
+  "private": true
 }


### PR DESCRIPTION
Found that using "private": true instead of a dummy "repository": "none" field also shuts up npm about the missing repository field and has the added benefit of preventing accidental publication of private repositories.

Gives a better example for people.