### PR TITLE
updated the highlight.js dependency to 8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "marked": "~0.3.0",
     "coffee-script": "~1.6.3",
     "async": "~0.2.9",
-    "highlight.js": "~8.0.0",
+    "highlight.js": "~8.2.0",
     "jade": "~1.1.5",
     "ncp": "~0.5.0",
     "rimraf": "~2.2.6",


### PR DESCRIPTION
highlight.js `8.0.0` -> `8.2.0`

My motivation behind this is to get support for their recently-improved support for scala syntax.