### PR TITLE
Fixed up inconsistencies in blog example (e.g. whitespace, quotes)

### DIFF
--- a/examples/blog/contents/articles/another-test/index.md
+++ b/examples/blog/contents/articles/another-test/index.md
@@ -131,8 +131,3 @@ print("Hello World")
 ```ruby
 puts "Hello world!"
 ```
-
-
-
-
-

--- a/examples/blog/contents/articles/bamboo-cutter/index.md
+++ b/examples/blog/contents/articles/bamboo-cutter/index.md
@@ -182,4 +182,3 @@ In spite of the impatience of the messengers and charioteers she kept them waiti
 Then the chariot began to roll heavenwards towards the moon, and as they all gazed with tearful eyes at the receding Princess, the dawn broke, and in the rosy light of day the moon-chariot and all in it were lost amongst the fleecy clouds that were now wafted across the sky on the wings of the morning wind.
 
 Princess Moonlight's letter was carried to the Palace. His Majesty was afraid to touch the Elixir of Life, so he sent it with the letter to the top of the most sacred mountain in the land. Mount Fuji, and there the Royal emissaries burnt it on the summit at sunrise. So to this day people say there is smoke to be seen rising from the top of Mount Fuji to the clouds.
-

--- a/examples/blog/contents/css/main.css
+++ b/examples/blog/contents/css/main.css
@@ -433,4 +433,3 @@ code.lang-markdown .bullet {
     margin-bottom: 1em;
   }
 }
-

--- a/examples/blog/templates/archive.jade
+++ b/examples/blog/templates/archive.jade
@@ -3,32 +3,30 @@ extends layout
 //- this logic should be moved to a view at some point
 
 block content
-	- var lineHeight = 2.2;
-	- var archives = _.chain(env.helpers.getArticles(contents)).groupBy(function(item) {
-	-	 return item.date.getFullYear()
-	- }).value()
-	- for (var archive in archives) {
-	-	archives[archive] = _.groupBy(archives[archive], function(item){return item.date.getMonth();})
-	- }
-	- var month_names = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
-	section.archive
-		h2 Archive
-		ul
-			- var yearsK = _.chain(archives).keys().reverse().value()
-			- for(var year in yearsK)
-				- months = archives[yearsK[year]]
-				- var yearHeight = lineHeight * _.reduce(months, function(memo,month) { return memo + month.length; }, 0);
-				li
-					span.year-label(style='line-height:' + yearHeight+'em')=yearsK[year]
-					ul(style='margin-left:4em')
-						- var monthsK = _.chain(months).keys().reverse().value()
-						- for(month in monthsK){
-							- var monthHeight = lineHeight * months[monthsK[month]].length
-							li
-								span.month-label(style='line-height:'+monthHeight+'em')=month_names[monthsK[month]]
-								ul(style='margin-left:7em')
-									each item in months[monthsK[month]]
-										li(style='height:'+ lineHeight + 'em;line-height:'+ lineHeight + 'em;')
-											a(href=item.url)=item.title
-						- }
-						
+  - var lineHeight = 2.2;
+  - var archives = _.chain(env.helpers.getArticles(contents)).groupBy(function(item) {
+  -   return item.date.getFullYear();
+  - }).value();
+  - for (var archive in archives) {
+  -   archives[archive] = _.groupBy(archives[archive], function(item) { return item.date.getMonth(); });
+  - }
+  - var month_names = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+  section.archive
+    h2 Archive
+    ul
+      - var yearsK = _.chain(archives).keys().reverse().value();
+      each yearK in yearsK
+        - var months = archives[yearK];
+        - var yearHeight = lineHeight * _.reduce(months, function(memo,month) { return memo + month.length; }, 0);
+        li
+          span.year-label(style='line-height:' + yearHeight + 'em')= yearK
+          ul(style='margin-left:4em')
+            - var monthsK = _.chain(months).keys().reverse().value();
+            each monthK in monthsK
+              - var monthHeight = lineHeight * months[monthK].length;
+              li
+                span.month-label(style='line-height:' + monthHeight + 'em')= month_names[monthK]
+                ul(style='margin-left:7em')
+                  each item in months[monthK]
+                    li(style='height:'+ lineHeight + 'em;line-height:' + lineHeight + 'em')
+                      a(href=item.url)= item.title

--- a/examples/blog/templates/article.jade
+++ b/examples/blog/templates/article.jade
@@ -5,13 +5,13 @@ block append vars
   - bodyclass = 'article-detail'
 
 block prepend title
-  | #{ page.title + " - "}
+  | #{ page.title + ' - '}
 
 block header
   include author
   h1= page.title
   p.author
-    | #{ "Written by " }
+    | #{ 'Written by ' }
     mixin author(page.metadata.author)
 
 block content
@@ -21,5 +21,3 @@ block content
 block prepend footer
   div.nav
     a(href=contents.index.url) « Full blog
-
-

--- a/examples/blog/templates/author.jade
+++ b/examples/blog/templates/author.jade
@@ -1,8 +1,8 @@
 
 mixin author(authorName)
-  - var author = contents.authors[authorName + '.json']
+  - var author = contents.authors[authorName + '.json'];
   span.author
     if author
-      a(href='mailto:'+author.metadata.email)= author.metadata.name
+      a(href='mailto:' + author.metadata.email)= author.metadata.name
     else
-      =authorName
+      = authorName

--- a/examples/blog/templates/feed.jade
+++ b/examples/blog/templates/feed.jade
@@ -13,8 +13,8 @@ rss(version='2.0',
     pubDate= articles[0].rfc822date
     generator Wintersmith - https://github.com/jnordberg/wintersmith
     language en
-    for article in articles
-      - var permalink = locals.url + article.url
+    each article in articles
+      - var permalink = locals.url + article.url;
       item
         title= article.title
         link= permalink

--- a/examples/blog/templates/index.jade
+++ b/examples/blog/templates/index.jade
@@ -1,3 +1,4 @@
+
 extends layout
 
 block content
@@ -24,6 +25,3 @@ block prepend footer
       a(href='/archive.html') « Archives
     if nextPage
       a(href=nextPage.url) Next page »
-
-
-


### PR DESCRIPTION
We are using `wintersmith` as our blog framework and noticed a lot of inconsistencies in the boilerplate example for the `blog` template. This PR attempts to fix them up. In this PR:

- Converted `archive.jade` from tab indentation to spaces indentation
- Added missing semicolons
- Guaranteed consistent spacing for functions `function(param) { /* body */ }`
- Moved to consistently use Jade loops outside of variable generation
- Always use `each` for loops in Jade
- Removed excess semicolons from inline styles
- Removed excess trailing whitespace in files (e.g. 5 newlines at end of a file)
- Always use single quotes in templates
- Added missing spaces around `+` and after `=` for a tag's content
- Added leading whitespace line for extended Jade templates