### PR TITLE
Hot plugin reloading

### DIFF
--- a/src/core/environment.coffee
+++ b/src/core/environment.coffee
@@ -156,6 +156,11 @@ class Environment extends EventEmitter
     @loadedModules.push id if unloadOnReset
     return rv
 
+  unloadModule: (module) ->
+    @logger.silly "unloading module: #{ module }"
+    id = @resolveModule module
+    delete require.cache[id]
+
   loadPluginModule: (module, callback) ->
     ### Load a plugin *module*. Calls *callback* when plugin is done loading, or an error ocurred. ###
     id = 'unknown'

--- a/src/core/environment.coffee
+++ b/src/core/environment.coffee
@@ -161,6 +161,10 @@ class Environment extends EventEmitter
     id = @resolveModule module
     delete require.cache[id]
 
+    loadedIndex = @loadedModules.indexOf id
+    if loadedIndex > -1
+      @loadedModules.splice(loadedIndex, 1)
+
   loadPluginModule: (module, callback) ->
     ### Load a plugin *module*. Calls *callback* when plugin is done loading, or an error ocurred. ###
     id = 'unknown'

--- a/src/core/environment.coffee
+++ b/src/core/environment.coffee
@@ -153,7 +153,7 @@ class Environment extends EventEmitter
     id = @resolveModule module
     @logger.silly "resolved: #{ id }"
     rv = require id
-    @loadedModules.push id if unloadOnReset
+    @loadedModules.push id
     return rv
 
   unloadModule: (module) ->

--- a/src/core/server.coffee
+++ b/src/core/server.coffee
@@ -120,6 +120,25 @@ setup = (env) ->
       block.localsLoad = false
       callback error
 
+  moduleWatcher = chokidar.watch env.loadedModules,
+    ignored: (path) ->
+      for pattern in env.config.ignore
+        if minimatch env.relativeContentsPath(path), pattern
+          return true
+
+      # dont include node_modules
+      if path.indexOf("#{env.workDir}/node_modules") != -1
+        return true
+
+      return false
+    ignoreInitial: true
+
+  moduleWatcher.on 'change', (path) ->
+    id = env.resolveModule path
+    env.unloadModule id
+    env.loadPluginModule id, ->
+      env.emit 'change', id
+
   contentWatcher = chokidar.watch env.contentsPath,
     ignored: (path) ->
       for pattern in env.config.ignore


### PR DESCRIPTION
Change something inside of paginator.coffee to see it work. Make sure wintersmith-livereload is installed.

Also, not sure what the point of ````unloadOnReset```` in ````loadModule```` is, I removed it so I could get a list of all loaded modules including plugins listed in the config.

And this currently only works with things like Paginator, but not for things like ContentPlugins. Would have to trigger a content re-render for all content that was relient on the reloaded plugin. But I dont think it would be too hard to extend to add that functionality.

@jnordberg is this something you're interested in?