### PR TITLE
Fallback to the normalized URI when determining the content type of files in the preview server

### DIFF
--- a/src/core/server.coffee
+++ b/src/core/server.coffee
@@ -229,7 +229,7 @@ setup = (env) ->
           renderView env, content, locals, tree, templates, (error, result) ->
             if error then callback error, 500, pluginName
             else if result?
-              mimeType = mime.lookup content.filename
+              mimeType = mime.lookup content.filename, mime.lookup(uri)
               charset = mime.charsets.lookup mimeType
               if charset
                 contentType = "#{ mimeType }; charset=#{ charset }"


### PR DESCRIPTION
Enables serving extensionless HTML files, since the normalized URI is `/path/index.html`

Without this, extensionless files are served as `application/octet-stream` (the default content type from the MIME module)