### PR TITLE
add config option to change the list of intro cutoff strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ plugins      | `[]`            | list of plugins to load
 ignore       | `[]`            | list of files or pattern to ignore
 output       | `./build`       | output directory, this is where the generated site is output when building
 filenameTemplate | `:file.html`| outputs filenames and paths according to a template. ([documentation](https://github.com/jnordberg/wintersmith/wiki/Page-Plugin#filename-templating))
+introCutoffs | `['<span class="more', '<h2', '<hr']` | list of strings to search for when determining if a page has an intro
 baseUrl      | `/`             | base url that site lives on, e.g. `/blog/`.
 hostname     | `null`          | hostname to bind preview server to, null = INADDR_ANY
 port         | `8080`          | port preview server listens on

--- a/src/plugins/page.coffee
+++ b/src/plugins/page.coffee
@@ -113,7 +113,7 @@ module.exports = (env, callback) ->
     @property 'intro', 'getIntro'
     getIntro: (base) ->
       html = @getHtml(base)
-      cutoffs = ['<span class="more', '<h2', '<hr']
+      cutoffs = env.config.introCutoffs or ['<span class="more', '<h2', '<hr']
       idx = Infinity
       for cutoff in cutoffs
         i = html.indexOf cutoff


### PR DESCRIPTION
With this patch users can customize "has more" indicators.

For example in my markdown I prefer to use `<!--more-->`.