### PR TITLE
Rename Jade to pug

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chokidar": "~1.4.2",
     "coffee-script": "~1.10.0",
     "highlight.js": "~9.2.0",
-    "pug": "~1.11.0",
+    "pug": "~0.1.0",
     "js-yaml": "~3.4.6",
     "marked": "~0.3.5",
     "mime": "~1.3.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chokidar": "~1.4.2",
     "coffee-script": "~1.10.0",
     "highlight.js": "~9.2.0",
-    "jade": "~1.11.0",
+    "pug": "~1.11.0",
     "js-yaml": "~3.4.6",
     "marked": "~0.3.5",
     "mime": "~1.3.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "chokidar": "~1.4.2",
     "coffee-script": "~1.10.0",
     "highlight.js": "~9.2.0",
-    "pug": "~0.1.0",
+    "pug": "~1.11.0",
     "js-yaml": "~3.4.6",
     "marked": "~0.3.5",
     "mime": "~1.3.4",


### PR DESCRIPTION
Hi @jnordberg, :smiley:

I edit the **`package.json`** file. :pencil:

> Because of the npm error: **`"WARN deprecated jade@1.11.0: Jade has been renamed to pug, please install the latest version of pug instead of jade"`**
#### See
- http://npmjs.org/package/pug
- https://github.com/pugjs/pug

_Yours,_
[**Suriyaa Kudo**](https://github.com/SuriyaaKudoIsc) :octocat:
