### PR TITLE
Set link for google fonts protocol relative

### DIFF
--- a/examples/blog/templates/layout.jade
+++ b/examples/blog/templates/layout.jade
@@ -11,7 +11,7 @@ html(lang='en')
         block title
           = locals.name
       link(rel='alternate', href=locals.url+'/feed.xml', type='application/rss+xml', title=locals.description)
-      link(rel='stylesheet', href='http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Anonymous+Pro:400,700,400italic,700italic|Merriweather:400,700,300')
+      link(rel='stylesheet', href='//fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Anonymous+Pro:400,700,400italic,700italic|Merriweather:400,700,300')
       link(rel='stylesheet', href=contents.css['main.css'].url)
   body(class=bodyclass)
     header.header


### PR DESCRIPTION
When I loaded site through https, I got:

```
Mixed Content: The page at 'https://blog.mysite.com/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Lora:400,700,400italic,700italic|Anonymous+Pro:400,700,400italic,700italic|Merriweather:400,700,300'. This request has been blocked; the content must be served over HTTPS.
```
