### PR TITLE
Adjust use of async.filter to take into account error argument.

### DIFF
--- a/src/core/content.coffee
+++ b/src/core/content.coffee
@@ -181,8 +181,8 @@ ContentTree.fromDirectory = (env, directory, callback) ->
             env.logger.verbose "ignoring #{ filename.relative } (matches: #{ pattern })"
             include = false
             break
-        callback include
-      , (result) -> callback null, result
+        callback null, include
+      , callback
     else
       callback null, filenames
 


### PR DESCRIPTION
caolan/async#1028 added support for errors in filter, which changed the
function's API.