### PR TITLE
Fixes Feed Not Displaying Author Name

### DIFF
--- a/examples/blog/templates/feed.jade
+++ b/examples/blog/templates/feed.jade
@@ -20,6 +20,7 @@ rss(version='2.0',
         link= permalink
         pubDate= article.rfc822date
         guid(isPermaLink='true')= permalink
-        author= article.author
+        - var author = contents.authors[article.metadata.author + '.json'];
+        author= author.metadata.name
         //- passing locals.url resolves all relative urls to absolute
         description= article.getHtml(locals.url)

--- a/examples/blog/templates/feed.jade
+++ b/examples/blog/templates/feed.jade
@@ -21,7 +21,9 @@ rss(version='2.0',
         pubDate= article.rfc822date
         guid(isPermaLink='true')= permalink
         - var author = contents.authors[article.metadata.author + '.json'];
-        - if (!author) {author = { metadata: {name: null}} };
-        author= author.metadata.name
+        if author
+            author= author.metadata.name
+        else
+            author= article.author
         //- passing locals.url resolves all relative urls to absolute
         description= article.getHtml(locals.url)

--- a/examples/blog/templates/feed.jade
+++ b/examples/blog/templates/feed.jade
@@ -21,6 +21,7 @@ rss(version='2.0',
         pubDate= article.rfc822date
         guid(isPermaLink='true')= permalink
         - var author = contents.authors[article.metadata.author + '.json'];
+        - if (!author) {author = { metadata: {name: null}} };
         author= author.metadata.name
         //- passing locals.url resolves all relative urls to absolute
         description= article.getHtml(locals.url)


### PR DESCRIPTION
By Default, the feed doesn't actually show the author name as it's not loaded

By creating a variable that correctly reads from the article metadata to pull in the JSON of the Author we can present the article author name in the feed.