### PR TITLE
Upgrade marked to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1075,9 +1075,9 @@
       "integrity": "sha1-KCBbVlqK51kt4gdGPWY33BgnIrI="
     },
     "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
     },
     "micromatch": {
       "version": "2.3.11",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "highlight.js": "^9.12.0",
     "jade-legacy": "^1.11.1",
     "js-yaml": "^3.7.0",
-    "marked": "^0.3.6",
+    "marked": "^0.3.12",
     "mime": "^1.3.4",
     "minimatch": "^3.0.3",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Related to two vulnerabilities reported by GitHub in repositories which use the latest version of Wintersmith:

![image](https://user-images.githubusercontent.com/11782/34943371-b3883550-f9fb-11e7-8866-2d3ed88aab62.png)
