### PR TITLE
Expose page when rendering Paginated pages

### DIFF
--- a/examples/blog/plugins/paginator.coffee
+++ b/examples/blog/plugins/paginator.coffee
@@ -46,7 +46,7 @@ module.exports = (env, callback) ->
         return callback new Error "unknown paginator template '#{ options.template }'"
 
       # setup the template context
-      ctx = {@articles, @pageNum, @prevPage, @nextPage}
+      ctx = {@articles, @pageNum, @prevPage, @nextPage, page: this}
 
       # extend the template context with the enviroment locals
       env.utils.extend ctx, locals


### PR DESCRIPTION
Useful if your templates expect a page object (e.g. pug include for site menu)